### PR TITLE
docs: refresh backend and frontend README guides

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -6,222 +6,109 @@ Spring Boot REST API for the DevBoard task management system.
 
 ### Prerequisites
 - Java 21+
-- Maven 3.9+
-- MySQL 8+ (for production) or H2 (for development)
+- Maven 3.9+ (or use included Maven wrapper)
+- MySQL 8+ (production) or H2 (development)
 
 ### Development Setup
 ```bash
-# Clone and navigate to backend
-cd devboard-backend
+cd apps/backend
 
-# Run with development profile (uses H2 database)
-mvn spring-boot:run -Dspring-boot.run.profiles=dev
+# Run with development profile (H2)
+./mvnw spring-boot:run -Dspring-boot.run.profiles=dev
 
 # Or build and run JAR
-mvn clean package
+./mvnw clean package
 java -jar target/devboard-0.0.1-SNAPSHOT.jar --spring.profiles.active=dev
 ```
 
-The API will be available at: `http://localhost:8080`
+API base URL: `http://localhost:8080`
 
 ## 🧪 Testing & Coverage
 
-### Run Unit Tests
 ```bash
-# Run all tests
-mvn test
-
-# Run specific test class
-mvn test -Dtest=TaskServiceTest
-```
-
-### Generate Coverage Report
-```bash
-# Generate JaCoCo coverage report
+cd apps/backend
+./mvnw test
 ./generate-coverage.sh
-
-# Or manually:
-mvn clean test
-open target/site/jacoco/index.html
 ```
 
-**Current Test Coverage:**
-- **Total Coverage**: 44% instruction coverage, 32% branch coverage
-- **Service Layer**: High coverage on core business logic
-  - AdminService: 100% line coverage
-  - CommentService: 97% line coverage
-  - UserService: 80% line coverage
-- **41 Unit Tests** covering service layer functionality
+Coverage report output:
+- `target/site/jacoco/index.html`
 
-## 📚 API Documentation
+## 📚 API Docs
 
-### Swagger UI
-Access interactive API documentation at: `http://localhost:8080/swagger-ui.html`
+- Swagger UI: `http://localhost:8080/swagger-ui.html`
+- H2 Console (dev): `http://localhost:8080/h2-console`
+  - JDBC URL: `jdbc:h2:mem:devboard_dev`
+  - Username: `sa`
+  - Password: *(empty)*
 
-### H2 Console (Development)
-Access H2 database console at: `http://localhost:8080/h2-console`
-- JDBC URL: `jdbc:h2:mem:devboard_dev`
-- Username: `sa`
-- Password: (empty)
+## 🏗️ Stack
 
-## 🏗️ Architecture
+- Spring Boot 3.3
+- Spring Security
+- Spring Data JPA
+- JWT (jjwt)
+- H2 / MySQL
+- Redis (Spring Data Redis)
+- JaCoCo
+- SpringDoc OpenAPI
 
-### Technology Stack
-- **Spring Boot 3.3** - Application framework
-- **Spring Security** - Authentication & authorization
-- **Spring Data JPA** - Data persistence
-- **JWT** - Token-based authentication
-- **H2/MySQL** - Database options
-- **JaCoCo** - Code coverage reporting
-- **Swagger/OpenAPI 3** - API documentation
+## 🔐 Auth & Roles
 
-### Project Structure
-```
-src/main/java/com/example/devboard/
-├── controller/          # REST controllers
-├── service/            # Business logic
-├── entity/             # JPA entities
-├── repository/         # Data access layer
-├── dto/               # Data transfer objects
-├── security/          # JWT & authentication
-├── config/            # Spring configuration
-├── exception/         # Global exception handling
-└── common/            # Shared utilities
-```
-
-## 🔐 Security
-
-### Authentication
 - JWT-based authentication
-- Token expiration: 24 hours
-- Refresh token mechanism included
+- Access roles:
+  - `USER`
+  - `ADMIN`
 
-### Authorization Levels
-- **USER**: Standard user permissions
-- **ADMIN**: Full system access
-
-### Default Credentials (Development)
-- Admin: `admin` / `admin123`
-- User: `user` / `user123`
-
-## 🗄️ Database
-
-### Development (H2)
-- In-memory database
-- Automatic schema creation
-- Sample data initialization
-
-### Production (MySQL)
-```bash
-# Set environment variables
-export DB_HOST=localhost
-export DB_PORT=3306
-export DB_NAME=devboard
-export DB_USERNAME=devboard_user
-export DB_PASSWORD=your_password
-
-# Run with production profile
-java -jar target/devboard-0.0.1-SNAPSHOT.jar --spring.profiles.active=prod
-```
+Development default credentials:
+- `admin` / `admin123`
+- `user` / `user123`
 
 ## 🔧 Configuration
 
-### Application Profiles
-- `dev` - Development (H2, debug logging)
-- `test` - Testing (H2, minimal logging)
-- `prod` - Production (MySQL, optimized)
+### Profiles
+- `dev`: H2 + local dev settings
+- `test`: test-oriented settings
+- `prod`: MySQL + production settings
 
-### Environment Variables
+### Environment Variables (common)
+
 ```bash
-# Database Configuration
 DB_HOST=localhost
 DB_PORT=3306
 DB_NAME=devboard
 DB_USERNAME=devboard_user
 DB_PASSWORD=your_secure_password
-
-# JWT Configuration
 JWT_SECRET=your_256_bit_secret_key_here
 JWT_EXPIRATION=86400000
-
-# Server Configuration
 SERVER_PORT=8080
 ```
 
-## 🚀 Deployment
+## 🐳 Docker
 
-### Docker
 ```bash
-# Build image
+cd apps/backend
 docker build -t devboard-backend .
-
-# Run container
 docker run -p 8080:8080 \
   -e SPRING_PROFILES_ACTIVE=prod \
   -e DB_HOST=your_db_host \
   devboard-backend
 ```
 
-### Docker Compose
-See `docker-compose.yml` in project root for full stack deployment.
-
-## 📊 Monitoring & Logging
-
-### Health Check
-- Endpoint: `GET /actuator/health`
-- Status: Application and database health
-
-### Logging
-- Development: Console output with debug level
-- Production: File-based logging with info level
-- Log location: `./backend.log`
-
-## 🛠️ Development
-
-### Code Quality
-```bash
-# Run tests with coverage
-mvn clean test
-
-# Build for production
-mvn clean package -Pprod
-```
-
-### Adding New Features
-1. Create entity classes in `entity/`
-2. Add repository interfaces in `repository/`
-3. Implement business logic in `service/`
-4. Create REST endpoints in `controller/`
-5. Add comprehensive unit tests
-6. Update API documentation
-
-### Testing Best Practices
-- Unit tests for service layer business logic
-- Integration tests for controller endpoints
-- Mock external dependencies
-- Maintain >80% coverage on service layer
-
-## 📋 API Endpoints
+## 📋 Core API Endpoints
 
 ### Authentication
-- `POST /api/auth/login` - User login
-- `POST /api/auth/register` - User registration
+- `POST /api/auth/login`
+- `POST /api/auth/register`
 
 ### Tasks
-- `GET /api/tasks` - List tasks with filters
-- `POST /api/tasks` - Create new task
-- `GET /api/tasks/{id}` - Get task details
-- `PUT /api/tasks/{id}` - Update task
-- `DELETE /api/tasks/{id}` - Delete task
+- `GET /api/tasks`
+- `POST /api/tasks`
+- `GET /api/tasks/{id}`
+- `PUT /api/tasks/{id}`
+- `DELETE /api/tasks/{id}`
 
 ### Comments
-- `GET /api/tasks/{taskId}/comments` - List task comments
-- `POST /api/tasks/{taskId}/comments` - Add comment
-- `DELETE /api/comments/{id}` - Delete comment
-
-### Admin
-- `GET /api/admin/users` - List all users
-- `GET /api/admin/dashboard` - Dashboard statistics
-- `PUT /api/admin/users/{id}/role` - Update user role
-
-For complete API documentation, visit the Swagger UI when the application is running.
+- `GET /api/tasks/{taskId}/comments`
+- `POST /api/tasks/{taskId}/comments`
+- `DELETE /api/comments/{id}`

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -1,5 +1,91 @@
-# Vue 3 + Vite
+# DevBoard Frontend
 
-This template should help get you started developing with Vue 3 in Vite. The template uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
+Vue 3 + Vite frontend for the DevBoard task management system.
 
-Learn more about IDE Support for Vue in the [Vue Docs Scaling up Guide](https://vuejs.org/guide/scaling-up/tooling.html#ide-support).
+## 🚀 Quick Start
+
+### Prerequisites
+- Node.js 20+
+- npm 10+
+
+### Install Dependencies
+```bash
+cd apps/frontend
+npm install
+```
+
+### Run Locally
+```bash
+npm run dev
+```
+
+Frontend runs at `http://localhost:5173` by default.
+
+> To connect with local backend, ensure `VITE_API_URL` points to your backend API (for example `http://localhost:8080`).
+
+## 📦 Available Scripts
+
+```bash
+npm run dev            # Start Vite dev server
+npm run build          # Production build
+npm run build:dev      # Development-mode build
+npm run preview        # Preview production build locally
+npm run lint           # Lint source files
+npm run lint:fix       # Lint and auto-fix
+npm run format         # Format src/ with Prettier
+npm run format:check   # Check formatting
+npm run test           # Run tests in watch mode
+npm run test:run       # Run tests once
+npm run test:coverage  # Run tests with coverage
+npm run test:ui        # Run Vitest UI
+```
+
+## 🧱 Tech Stack
+- Vue 3
+- Vue Router
+- Axios
+- Vite
+- Vitest + Testing Library
+- ESLint + Prettier
+
+## 📁 Project Structure
+
+```text
+apps/frontend/
+├── src/
+│   ├── components/    # Reusable UI components
+│   ├── views/         # Route-level pages
+│   ├── router/        # Router configuration
+│   ├── services/      # API and service modules
+│   └── tests/         # Unit/component tests
+├── public/            # Static assets
+└── vite.config.js     # Vite config
+```
+
+## 🔧 Environment Variables
+
+Use `.env.local` (not committed) for local overrides.
+
+Common variables:
+
+```bash
+VITE_API_URL=http://localhost:8080
+```
+
+You can copy from `.env.local.example` as a starting point.
+
+## 🐳 Docker
+
+```bash
+# Build image
+cd apps/frontend
+docker build -t devboard-frontend .
+
+# Run container
+docker run -p 80:80 devboard-frontend
+```
+
+## ✅ Development Notes
+- Keep components small and composable.
+- Prefer service modules for API calls over in-component request logic.
+- Add/update tests when changing behavior.


### PR DESCRIPTION
### Motivation
- Make the frontend README project-specific with clear local setup, scripts, environment variable guidance, and Docker usage. 
- Correct and standardize backend README paths and commands so developers use the repository layout and the included Maven wrapper.

### Description
- Rewrote `apps/frontend/README.md` with quick start steps, prerequisites, available `npm` scripts, tech stack, project structure, environment variable guidance, Docker build/run commands, and development notes. 
- Updated `apps/backend/README.md` to use `apps/backend` paths and the Maven wrapper (`./mvnw`) for running, building, and testing, and streamlined testing/coverage, API docs, stack, auth/roles, configuration, and Docker sections. 
- Added explicit command examples such as `cd apps/frontend && npm install`, `npm run dev`, `cd apps/backend && ./mvnw test`, and referenced the JaCoCo coverage report at `target/site/jacoco/index.html`. 
- Removed default template boilerplate and consolidated content so the READMEs are concise and actionable for local development.

### Testing
- No automated tests were executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db5fdf46ec8331b3c2c46f50fbb743)