### PR TITLE
Fix frontend container healthcheck when nginx redirects HTTP to HTTPS

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -71,8 +71,11 @@ RUN chown -R nginx:nginx /usr/share/nginx/html && \
 EXPOSE 80
 
 # Add healthcheck
+# Note: some deployments redirect HTTP->HTTPS (301) on `/`.
+# Try HTTP first, then fall back to HTTPS for redirect-based configs.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:80/ || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:80/ || \
+      wget --no-verbose --tries=1 --spider --no-check-certificate https://127.0.0.1:443/ || exit 1
 
 # Start Nginx with dumb-init for proper signal handling
 ENTRYPOINT ["dumb-init", "--"]


### PR DESCRIPTION
### Motivation
- Prevent the frontend container from being marked `unhealthy` in deployments where the nginx config redirects all HTTP `/` requests to HTTPS (301), while preserving non-TLS health checks.

### Description
- Update `apps/frontend/Dockerfile` to make the `HEALTHCHECK` try `http://127.0.0.1:80/` first and, on failure/redirect, fall back to `https://127.0.0.1:443/` with `--no-check-certificate`, so redirect-based TLS setups are treated as healthy.

### Testing
- Ran repository inspections and validations (`rg -n ...`, `sed -n ...`, `nl -ba ...`) and performed `git add`/`git commit` to apply the change, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db7902f1008331aaf0bce20ea2356f)