### PR TITLE
Expose frontend HTTPS (443) on single-VM and add HTTPS env vars to Jenkins pipeline

### DIFF
--- a/ci/jenkins/Jenkinsfile.vm
+++ b/ci/jenkins/Jenkinsfile.vm
@@ -143,9 +143,10 @@ MYSQL_PASSWORD=devboard_pass
 
 MYSQL_PORT=3307
 BACKEND_PORT=8080
-FRONTEND_PORT=80
+FRONTEND_HTTP_PORT=80
+FRONTEND_HTTPS_PORT=443
 
-CORS_ALLOWED_ORIGINS=http://${params.VM_IP}:80,http://localhost:80
+CORS_ALLOWED_ORIGINS=http://${params.VM_IP}:80,https://${params.VM_IP}:443,http://localhost:80
 EOF
 
                     echo "Generated ${ENV_FILE_NAME}:"
@@ -205,6 +206,7 @@ EOF
     post {
         success {
             echo "Deployment succeeded. Frontend: http://${params.VM_IP}:80"
+            echo "Deployment succeeded. Frontend (HTTPS): https://${params.VM_IP}:443"
             echo "Backend: http://${params.VM_IP}:8080"
         }
         failure {

--- a/deploy/docker-compose/single-vm/docker-compose.yml
+++ b/deploy/docker-compose/single-vm/docker-compose.yml
@@ -47,7 +47,8 @@ services:
     container_name: devboard-frontend
     restart: unless-stopped
     ports:
-      - "${FRONTEND_PORT}:80"
+      - "${FRONTEND_HTTP_PORT:-80}:80"
+      - "${FRONTEND_HTTPS_PORT:-443}:443"
     depends_on:
       - backend
     volumes:


### PR DESCRIPTION
### Motivation
- `ss -tulnp` on the VM showed port 80 listening but not 443, while the frontend nginx config expects to listen on 443 inside the container. 
- The frontend container was only publishing host port to container port 80, so HTTPS traffic was not exposed on the host. 
- The deployment pipeline needed to generate separate HTTP/HTTPS port env vars and include the HTTPS origin in CORS to match the runtime bindings.

### Description
- Updated `deploy/docker-compose/single-vm/docker-compose.yml` to publish both host HTTP and HTTPS with environment-configurable ports using `FRONTEND_HTTP_PORT` and `FRONTEND_HTTPS_PORT` (defaults to `80` and `443`).
- Replaced the single `FRONTEND_PORT` entry in `ci/jenkins/Jenkinsfile.vm` with `FRONTEND_HTTP_PORT` and `FRONTEND_HTTPS_PORT` in the generated `.env` file. 
- Added the HTTPS origin to `CORS_ALLOWED_ORIGINS` in the generated env file and updated the pipeline success logs to print the HTTPS endpoint. 

### Testing
- Verified code references using `rg -n "FRONTEND_PORT|FRONTEND_HTTP_PORT|FRONTEND_HTTPS_PORT"` which showed the updated keys in the compose and Jenkins pipeline files. 
- Reviewed the patch with `git diff` to confirm the intended changes to `docker-compose.yml` and `Jenkinsfile.vm`. 
- Ran `git status --short` to confirm the two files were modified. 
- Attempted `docker compose -f deploy/docker-compose/single-vm/docker-compose.yml config` to render the compose but it failed because the `docker` CLI is not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db7b91b5688331bc2d3969fa98cd1a)