### PR TITLE
Automate conditional TLS provisioning in VM Jenkins deployment pipeline

### DIFF
--- a/ci/jenkins/Jenkinsfile.vm
+++ b/ci/jenkins/Jenkinsfile.vm
@@ -12,11 +12,14 @@ pipeline {
         string(name: 'VM_IP', defaultValue: '', description: 'Target VM public IP')
         string(name: 'SSH_USER', defaultValue: '', description: 'SSH user for target VM')
         string(name: 'DEPLOY_PATH', defaultValue: '/opt/devboard', description: 'Deployment path on target VM')
+        string(name: 'DOMAIN_NAME', defaultValue: 'smtdevboard.com', description: 'Public domain used for TLS certificates')
+        string(name: 'LETSENCRYPT_EMAIL', defaultValue: 'sunmingtao@gmail.com', description: 'Email used for Let\'s Encrypt registration')
         string(name: 'DOCKER_IMAGE_TAG', defaultValue: '', description: 'Optional Docker image tag override. Leave blank to use BUILD_NUMBER')
         string(name: 'DEPLOYMENT_MODE_DIR', defaultValue: 'deploy/docker-compose/single-vm', description: 'Deployment configuration directory')
         string(name: 'SSH_CREDENTIAL_ID', defaultValue: '', description: 'Jenkins SSH credential ID')
         choice(name: 'ENVIRONMENT', choices: ['dev', 'prod'], description: 'Target environment')
         choice(name: 'DEPLOY_MODE', choices: ['build_and_push', 'pull_only'], description: 'Deployment mode')
+        booleanParam(name: 'AUTO_MANAGE_TLS', defaultValue: true, description: 'Automatically provision or renew TLS certificates only when required')
     }
 
     environment {
@@ -47,6 +50,12 @@ pipeline {
                     if (!params.DEPLOY_PATH?.trim()) {
                         error("DEPLOY_PATH is required")
                     }
+                    if (!params.DOMAIN_NAME?.trim()) {
+                        error("DOMAIN_NAME is required")
+                    }
+                    if (!params.LETSENCRYPT_EMAIL?.trim()) {
+                        error("LETSENCRYPT_EMAIL is required")
+                    }
                     if (params.DEPLOY_MODE == 'pull_only' && !params.DOCKER_IMAGE_TAG?.trim()) {
                         error("DOCKER_IMAGE_TAG is required when DEPLOY_MODE is pull_only")
                     }
@@ -69,9 +78,11 @@ pipeline {
                     echo "VM IP: ${params.VM_IP}"
                     echo "SSH User: ${params.SSH_USER}"
                     echo "Deploy Path: ${params.DEPLOY_PATH}"
+                    echo "Domain Name: ${params.DOMAIN_NAME}"
                     echo "Image Tag: ${EFFECTIVE_IMAGE_TAG}"
                     echo "Deploy Mode: ${params.DEPLOY_MODE}"
                     echo "Environment: ${params.ENVIRONMENT}"
+                    echo "Auto TLS: ${params.AUTO_MANAGE_TLS}"
                 """
             }
         }
@@ -172,12 +183,33 @@ EOF
                         scp -O -o StrictHostKeyChecking=no ${params.DEPLOYMENT_MODE_DIR}/${COMPOSE_FILE} ${params.SSH_USER}@${params.VM_IP}:${params.DEPLOY_PATH}/${COMPOSE_FILE}
                         scp -O -o StrictHostKeyChecking=no ${params.DEPLOYMENT_MODE_DIR}/docker-compose.${params.ENVIRONMENT}.yml ${params.SSH_USER}@${params.VM_IP}:${params.DEPLOY_PATH}/docker-compose.${params.ENVIRONMENT}.yml
                         scp -O -o StrictHostKeyChecking=no deploy/nginx/nginx.http.conf ${params.SSH_USER}@${params.VM_IP}:${params.DEPLOY_PATH}/nginx.http.conf
-                        scp -O -o StrictHostKeyChecking=no deploy/nginx/nginx.https.conf ${params.SSH_USER}@${params.VM_IP}:${params.DEPLOY_PATH}/nginx.https.conf
+                        scp -O -o StrictHostKeyChecking=no deploy/nginx/nginx.https.conf ${params.SSH_USER}@${params.VM_IP}:${params.DEPLOY_PATH}/nginx.https.template.conf
                         scp -O -o StrictHostKeyChecking=no ${ENV_FILE_NAME} ${params.SSH_USER}@${params.VM_IP}:${params.DEPLOY_PATH}/.env
 
                         ssh -o StrictHostKeyChecking=no ${params.SSH_USER}@${params.VM_IP} '
                             set -eux
                             cd ${params.DEPLOY_PATH}
+
+                            CERT_PATH="certbot/conf/live/${params.DOMAIN_NAME}/fullchain.pem"
+
+                            if [ "${params.AUTO_MANAGE_TLS}" = "true" ]; then
+                                if [ -f "$CERT_PATH" ] && openssl x509 -checkend 2592000 -noout -in "$CERT_PATH"; then
+                                    echo "Valid certificate already present for ${params.DOMAIN_NAME}. Using HTTPS config."
+                                    cp nginx.https.template.conf nginx.https.conf
+                                else
+                                    echo "Certificate missing or expiring within 30 days. Running one-time certbot issuance/renewal."
+                                    cp nginx.http.conf nginx.https.conf
+                                    docker compose -f docker-compose.yml -f docker-compose.${params.ENVIRONMENT}.yml pull frontend certbot
+                                    docker compose -f docker-compose.yml -f docker-compose.${params.ENVIRONMENT}.yml up -d --no-deps frontend
+                                    docker compose -f docker-compose.yml -f docker-compose.${params.ENVIRONMENT}.yml run --rm certbot certonly --webroot -w /var/www/certbot -d ${params.DOMAIN_NAME} --email ${params.LETSENCRYPT_EMAIL} --agree-tos --no-eff-email
+                                    cp nginx.https.template.conf nginx.https.conf
+                                    docker compose -f docker-compose.yml -f docker-compose.${params.ENVIRONMENT}.yml up -d --no-deps frontend
+                                fi
+                            else
+                                echo "AUTO_MANAGE_TLS=false, deploying with HTTPS config as-is."
+                                cp nginx.https.template.conf nginx.https.conf
+                            fi
+
                             docker compose -f docker-compose.yml -f docker-compose.${params.ENVIRONMENT}.yml pull
                             docker compose -f docker-compose.yml -f docker-compose.${params.ENVIRONMENT}.yml up -d --remove-orphans
                             docker compose -f docker-compose.yml -f docker-compose.${params.ENVIRONMENT}.yml ps


### PR DESCRIPTION
### Motivation
- Remove the manual certbot + nginx swap workflow by making Jenkins handle TLS issuance and renewal automatically but only when necessary.
- Avoid reinstalling certificates on every deploy while ensuring HTTPS is enabled when a valid certificate exists or is successfully issued.

### Description
- Added pipeline parameters `DOMAIN_NAME`, `LETSENCRYPT_EMAIL`, and `AUTO_MANAGE_TLS` to `ci/jenkins/Jenkinsfile.vm` for domain, registration email, and an automation toggle.
- Added parameter validation and pipeline logging for the new TLS inputs so misconfiguration fails early and is visible in build output.
- Upload the HTTPS nginx config as `nginx.https.template.conf` and, during the VM deploy step, check `certbot/conf/live/${params.DOMAIN_NAME}/fullchain.pem` with `openssl x509 -checkend 2592000` to determine whether to run certbot.
- If the cert is missing or expiring within 30 days, switch nginx to the HTTP challenge config, start the frontend to serve the ACME webroot, run `certbot certonly --webroot`, then restore the HTTPS template and continue the normal `docker compose` deployment; when `AUTO_MANAGE_TLS` is `false` the HTTPS template is deployed as-is.

### Testing
- Ran `git diff --check` which returned no issues.
- Ran `git status --short` to verify the change shows as modified and it succeeded.
- Committed the change with `git commit -m "Automate conditional TLS provisioning in VM Jenkins pipeline"` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db7f7f8fa48331a2b89fd222192106)