### PR TITLE
Escape CERT_PATH to avoid Groovy interpolation in VM Jenkins pipeline

### DIFF
--- a/ci/jenkins/Jenkinsfile.vm
+++ b/ci/jenkins/Jenkinsfile.vm
@@ -193,7 +193,7 @@ EOF
                             CERT_PATH="certbot/conf/live/${params.DOMAIN_NAME}/fullchain.pem"
 
                             if [ "${params.AUTO_MANAGE_TLS}" = "true" ]; then
-                                if [ -f "$CERT_PATH" ] && openssl x509 -checkend 2592000 -noout -in "$CERT_PATH"; then
+                                if [ -f "\$CERT_PATH" ] && openssl x509 -checkend 2592000 -noout -in "\$CERT_PATH"; then
                                     echo "Valid certificate already present for ${params.DOMAIN_NAME}. Using HTTPS config."
                                     cp nginx.https.template.conf nginx.https.conf
                                 else


### PR DESCRIPTION
### Motivation
- The Deploy to VM stage was failing with `groovy.lang.MissingPropertyException: No such property: CERT_PATH` because `$CERT_PATH` inside a Groovy-interpolated `sh """ ... """` block was being parsed as a Groovy property instead of a shell variable on the remote VM.

### Description
- Escape the CERT_PATH reference in `ci/jenkins/Jenkinsfile.vm` by changing `"$CERT_PATH"` to `"\$CERT_PATH"` so the variable is evaluated by the remote shell during the Deploy to VM stage.

### Testing
- Confirmed the escaped usage with `rg -n '\$CERT_PATH|CERT_PATH' ci/jenkins/Jenkinsfile.vm` and observed the expected match (success).
- Verified the file change with `git -C /workspace/devBoard diff -- ci/jenkins/Jenkinsfile.vm` (success).
- Committed the fix with `git -C /workspace/devBoard commit -m "Fix Jenkins CERT_PATH interpolation in VM deploy pipeline"` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db88b54c8c8331b1f71ebd4d65486b)