### PR TITLE
Support legacy DB_* env vars and add RDS MySQL auth troubleshooting

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -73,7 +73,16 @@ Development default credentials:
 
 ### Environment Variables (common)
 
+The backend now supports both `DATABASE_*` and legacy `DB_*` variable names.
+`DATABASE_*` takes precedence when both are set.
+
 ```bash
+# Preferred names
+DATABASE_URL=jdbc:mysql://localhost:3306/devboard?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+DATABASE_USERNAME=devboard_user
+DATABASE_PASSWORD=your_secure_password
+
+# Legacy names (still supported)
 DB_HOST=localhost
 DB_PORT=3306
 DB_NAME=devboard
@@ -94,6 +103,24 @@ docker run -p 8080:8080 \
   -e DB_HOST=your_db_host \
   devboard-backend
 ```
+
+### RDS connection troubleshooting (`Access denied for user ...`)
+
+If startup fails with `java.sql.SQLException: Access denied for user ...`, this is usually a MySQL auth issue (credentials or grants), not a security-group reachability issue.
+
+1. Confirm your task/service is using the expected DB variables (`DATABASE_USERNAME` / `DATABASE_PASSWORD` or `DB_USERNAME` / `DB_PASSWORD`).
+2. Verify the user exists on RDS and can connect from `%` (or your app subnet CIDR host pattern):
+   ```sql
+   SELECT user, host FROM mysql.user WHERE user = 'devboard_user';
+   SHOW GRANTS FOR 'devboard_user'@'%';
+   ```
+3. If needed, recreate grants:
+   ```sql
+   CREATE USER IF NOT EXISTS 'devboard_user'@'%' IDENTIFIED BY '***';
+   GRANT ALL PRIVILEGES ON devboard.* TO 'devboard_user'@'%';
+   FLUSH PRIVILEGES;
+   ```
+4. Security groups are likely fine if you see `Access denied`; SG/NACL issues typically surface as timeout/refused errors.
 
 ## 📋 Core API Endpoints
 

--- a/apps/backend/src/main/resources/application-mysql.yml
+++ b/apps/backend/src/main/resources/application-mysql.yml
@@ -4,11 +4,11 @@
 spring:
   # MySQL Database Configuration (Container-friendly)
   datasource:
-    # Use environment variables with container-friendly defaults
-    url: ${DATABASE_URL:jdbc:mysql://mysql:3306/devboard?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC&createDatabaseIfNotExist=true}
+    # Prefer DATABASE_* variables, but support legacy DB_* names too
+    url: ${DATABASE_URL:${DB_URL:jdbc:mysql://${DB_HOST:mysql}:${DB_PORT:3306}/${DB_NAME:devboard}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC&createDatabaseIfNotExist=true}}
     driver-class-name: com.mysql.cj.jdbc.Driver
-    username: ${DATABASE_USERNAME:devboard_user}
-    password: ${DATABASE_PASSWORD:devboard_pass}
+    username: ${DATABASE_USERNAME:${DB_USERNAME:devboard_user}}
+    password: ${DATABASE_PASSWORD:${DB_PASSWORD:devboard_pass}}
     
     # MySQL Connection pool configuration
     hikari:

--- a/apps/backend/src/main/resources/application-prod.yml
+++ b/apps/backend/src/main/resources/application-prod.yml
@@ -5,9 +5,9 @@ spring:
   # Production Database Configuration
   datasource:
     # Production should use MySQL or PostgreSQL
-    url: ${DATABASE_URL:jdbc:mysql://localhost:3306/devboard_prod?useSSL=true&requireSSL=true&serverTimezone=UTC}
-    username: ${DATABASE_USERNAME:devboard_prod_user}
-    password: ${DATABASE_PASSWORD:}
+    url: ${DATABASE_URL:${DB_URL:jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:devboard_prod}?useSSL=true&requireSSL=true&serverTimezone=UTC}}
+    username: ${DATABASE_USERNAME:${DB_USERNAME:devboard_prod_user}}
+    password: ${DATABASE_PASSWORD:${DB_PASSWORD:}}
     driver-class-name: com.mysql.cj.jdbc.Driver
     
     # Connection pool configuration for production


### PR DESCRIPTION
### Motivation

- The backend was failing to start with `Access denied for user 'devboard_user'@'10.x.x.x'`, indicating an authentication/grants issue rather than network reachability, often caused by mismatched environment variable names or incorrect grants.
- Make configuration more robust to environments using older `DB_*` names while preferring modern `DATABASE_*` names to reduce silent misconfiguration.
- Provide clear operator guidance to quickly distinguish MySQL auth errors from security-group/network issues.

### Description

- Updated `apps/backend/src/main/resources/application-mysql.yml` to prefer `DATABASE_*` variables but fall back to legacy `DB_*` variables for `url`, `username`, and `password` using nested Spring property defaults (`${DATABASE_URL:${DB_URL:...}}`, etc.).
- Applied the same compatibility change to `apps/backend/src/main/resources/application-prod.yml` so the production profile behaves consistently.
- Expanded `apps/backend/README.md` to document preferred `DATABASE_*` vs legacy `DB_*` environment variables (and precedence) and added an RDS troubleshooting section with `SELECT user, host FROM mysql.user`, `SHOW GRANTS`, and example `CREATE USER`/`GRANT` commands and guidance explaining that `Access denied` typically signals auth/grant issues, not security-group reachability.

### Testing

- Attempted an automated package build with `cd apps/backend && ./mvnw -q -DskipTests package`; the build could not complete because the Maven wrapper failed to download required artifacts (`wget` failed to fetch from `repo.maven.apache.org`).
- No other automated tests were executed in this environment due to the above network/download failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb36f1fd48331a99ce32c34ae32d1)