### PR TITLE
Update GitHub Actions to use apps/backend and apps/frontend paths

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -5,12 +5,12 @@ on:
   push:
     branches: [ main, release ]
     paths:
-      - 'devboard-backend/**'
+      - 'apps/backend/**'
       - '.github/workflows/backend.yml'
   pull_request:
     branches: [ main ]
     paths:
-      - 'devboard-backend/**'
+      - 'apps/backend/**'
 
 # Environment variables available to all jobs
 env:
@@ -65,7 +65,7 @@ jobs:
 
       # Step 4: Run tests
       - name: Run Tests
-        working-directory: ./devboard-backend
+        working-directory: ./apps/backend
         run: |
           mvn clean test
         env:
@@ -76,7 +76,7 @@ jobs:
 
       # Step 5: Build application
       - name: Build with Maven
-        working-directory: ./devboard-backend
+        working-directory: ./apps/backend
         run: mvn clean package -DskipTests
 
       # Step 6: Upload JAR artifact
@@ -84,7 +84,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: backend-jar
-          path: devboard-backend/target/*.jar
+          path: apps/backend/target/*.jar
           retention-days: 1
 
   # Job 2: Build Docker Image (only on main branch)
@@ -104,7 +104,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: backend-jar
-          path: devboard-backend/target
+          path: apps/backend/target
 
       # Step 3: Set up Docker Buildx
       - name: Set up Docker Buildx
@@ -137,7 +137,7 @@ jobs:
       - name: Build Docker image (local only)
         uses: docker/build-push-action@v5
         with:
-          context: ./devboard-backend
+          context: ./apps/backend
           push: false  # Just build, don't push anywhere
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'devboard-backend/**'
+      - 'apps/backend/**'
       - '.github/workflows/deploy-backend.yml'
 
 env:
@@ -37,11 +37,11 @@ jobs:
         restore-keys: ${{ runner.os }}-m2
     
     - name: Run tests
-      working-directory: ./devboard-backend
+      working-directory: ./apps/backend
       run: mvn test
       
     - name: Build with Maven
-      working-directory: ./devboard-backend
+      working-directory: ./apps/backend
       run: mvn package
     
     - name: Configure AWS credentials
@@ -56,7 +56,7 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v1
     
     - name: Build, tag, and push image to Amazon ECR
-      working-directory: ./devboard-backend
+      working-directory: ./apps/backend
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         IMAGE_TAG: ${{ github.sha }}

--- a/.github/workflows/deploy-dev-backend.yml
+++ b/.github/workflows/deploy-dev-backend.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - develop
     paths:
-      - 'devboard-backend/**'
+      - 'apps/backend/**'
       - '.github/workflows/deploy-dev-backend.yml'
   workflow_dispatch:
 
@@ -24,7 +24,7 @@ jobs:
         distribution: 'temurin'
     
     - name: Build with Maven
-      working-directory: ./devboard-backend
+      working-directory: ./apps/backend
       run: |
         mvn clean compile test package
         ls -la target/
@@ -41,7 +41,7 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v1
     
     - name: Build and push Docker image
-      working-directory: ./devboard-backend
+      working-directory: ./apps/backend
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: devboard-backend

--- a/.github/workflows/deploy-dev-frontend.yml
+++ b/.github/workflows/deploy-dev-frontend.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - develop
     paths:
-      - 'devboard-frontend/**'
+      - 'apps/frontend/**'
       - '.github/workflows/deploy-dev-frontend.yml'
   workflow_dispatch:
 
@@ -23,11 +23,11 @@ jobs:
         node-version: '18'
     
     - name: Install dependencies
-      working-directory: ./devboard-frontend
+      working-directory: ./apps/frontend
       run: npm ci
     
     - name: Run tests
-      working-directory: ./devboard-frontend
+      working-directory: ./apps/frontend
       run: npm run test:run || echo "Tests failed but continuing deployment"
       continue-on-error: true
     
@@ -63,7 +63,7 @@ jobs:
         echo "Development CloudFront domain: $CF_DOMAIN"
 
     - name: Build frontend for development
-      working-directory: ./devboard-frontend
+      working-directory: ./apps/frontend
       env:
         # Replace placeholder with actual CloudFront domain
         VITE_API_URL: https://${{ steps.get-dev-cf-domain.outputs.DEV_CF_DOMAIN }}
@@ -93,7 +93,7 @@ jobs:
         echo "CF_DIST_ID=$CF_DIST_ID" >> $GITHUB_OUTPUT
     
     - name: Deploy to S3
-      working-directory: ./devboard-frontend
+      working-directory: ./apps/frontend
       run: |
         aws s3 sync dist/ s3://${{ steps.get-resources.outputs.S3_BUCKET }} --delete
     

--- a/.github/workflows/deploy-dev-full-stack.yml
+++ b/.github/workflows/deploy-dev-full-stack.yml
@@ -35,7 +35,7 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v1
     
     - name: Build and push backend Docker image
-      working-directory: ./devboard-backend
+      working-directory: ./apps/backend
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: devboard-backend
@@ -89,7 +89,7 @@ jobs:
         echo "ALB_DNS=$ALB_DNS" >> $GITHUB_OUTPUT
     
     - name: Build and push frontend Docker image
-      working-directory: ./devboard-frontend
+      working-directory: ./apps/frontend
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: devboard-frontend

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'devboard-frontend/**'
+      - 'apps/frontend/**'
       - '.github/workflows/deploy-frontend.yml'
 
 jobs:
@@ -22,15 +22,15 @@ jobs:
         node-version: '18'
         
     - name: Install dependencies
-      working-directory: ./devboard-frontend
+      working-directory: ./apps/frontend
       run: npm ci
       
     - name: Run tests
-      working-directory: ./devboard-frontend
+      working-directory: ./apps/frontend
       run: npm run test:run
       
     - name: Build frontend
-      working-directory: ./devboard-frontend
+      working-directory: ./apps/frontend
       run: npm run build
       
     - name: Configure AWS credentials
@@ -41,7 +41,7 @@ jobs:
         aws-region: us-east-1
         
     - name: Deploy to S3
-      working-directory: ./devboard-frontend
+      working-directory: ./apps/frontend
       run: |
         aws s3 sync dist/ s3://devboard-frontend-627073650332 --delete
         

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -5,12 +5,12 @@ on:
   push:
     branches: [ main, release ]
     paths:
-      - 'devboard-frontend/**'
+      - 'apps/frontend/**'
       - '.github/workflows/frontend.yml'
   pull_request:
     branches: [ main ]
     paths:
-      - 'devboard-frontend/**'
+      - 'apps/frontend/**'
 
 # Environment variables
 env:
@@ -34,26 +34,26 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          cache-dependency-path: devboard-frontend/package-lock.json
+          cache-dependency-path: apps/frontend/package-lock.json
 
       # Step 3: Install dependencies
       - name: Install dependencies
-        working-directory: ./devboard-frontend
+        working-directory: ./apps/frontend
         run: npm ci
 
       # Step 4: Run linting
       - name: Run ESLint
-        working-directory: ./devboard-frontend
+        working-directory: ./apps/frontend
         run: npm run lint || true  # Don't fail on lint warnings
 
       # Step 5: Run tests
       - name: Run tests
-        working-directory: ./devboard-frontend
+        working-directory: ./apps/frontend
         run: npm run test:run
 
       # Step 6: Build production bundle
       - name: Build for production
-        working-directory: ./devboard-frontend
+        working-directory: ./apps/frontend
         run: |
           npm run build
           # Verify build output
@@ -64,12 +64,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: frontend-dist
-          path: devboard-frontend/dist/
+          path: apps/frontend/dist/
           retention-days: 7
 
       # Step 8: Check bundle size
       - name: Analyze bundle size
-        working-directory: ./devboard-frontend
+        working-directory: ./apps/frontend
         run: |
           echo "=== Bundle Size Analysis ==="
           echo "Total dist size:"
@@ -114,7 +114,7 @@ jobs:
       - name: Build Docker image (local only)
         uses: docker/build-push-action@v5
         with:
-          context: ./devboard-frontend
+          context: ./apps/frontend
           push: false  # Just build, don't push
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -150,7 +150,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: frontend-dist
-          path: devboard-frontend/dist/
+          path: apps/frontend/dist/
 
       # Step 3: Deploy preview (placeholder for Vercel/Netlify)
       - name: Deploy Preview
@@ -185,11 +185,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: frontend-dist
-          path: devboard-frontend/dist/
+          path: apps/frontend/dist/
 
       # Step 3: Serve the app locally
       - name: Serve app
-        working-directory: ./devboard-frontend
+        working-directory: ./apps/frontend
         run: |
           npm install -g serve
           serve -s dist -p 3000 &
@@ -204,7 +204,7 @@ jobs:
           uploadArtifacts: true
           temporaryPublicStorage: true
           # Performance budget
-          budgetPath: ./devboard-frontend/.lighthouserc.json
+          budgetPath: ./apps/frontend/.lighthouserc.json
 
       # Step 5: Comment results on PR (if applicable)
       - name: Format Lighthouse results


### PR DESCRIPTION
### Motivation
- Replace legacy `devboard-backend`/`devboard-frontend` path references so CI/CD workflows trigger and run against the current monorepo layout under `apps/backend` and `apps/frontend`.
- Ensure workflows use correct `working-directory`, artifact paths, Docker build contexts, cache paths, and Lighthouse budget so steps operate on the actual project folders.

### Description
- Updated workflow trigger globs from `'devboard-backend/**'` and `'devboard-frontend/**'` to `'apps/backend/**'` and `'apps/frontend/**'` in multiple files under `.github/workflows`.
- Replaced all filesystem references in workflows including `working-directory`, upload/download artifact `path`, Docker `context`, npm cache dependency path, and Lighthouse `budgetPath` to point to `./apps/backend` or `./apps/frontend` as appropriate.
- Modified the following workflow files: `backend.yml`, `frontend.yml`, `deploy-backend.yml`, `deploy-dev-backend.yml`, `deploy-frontend.yml`, `deploy-dev-frontend.yml`, and `deploy-dev-full-stack.yml`.

### Testing
- Verified no remaining legacy workflow globs or `./devboard-*` references in `.github/workflows` using `rg` (search completed successfully).
- Ran `git diff --check` to validate there are no whitespace or diff hygiene issues and the check passed.
- Committed the changes (7 files changed), ensuring the updated workflows are staged and recorded in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0b71166c833182dafbd5ef74c5c4)