### PR TITLE
Add Kafka producer for task events with config and unit tests

### DIFF
--- a/apps/backend/pom.xml
+++ b/apps/backend/pom.xml
@@ -79,6 +79,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-redis</artifactId>
 		</dependency>
+		<!-- Apache Kafka -->
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
 		<!-- JWT -->
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>

--- a/apps/backend/src/main/java/com/example/devboard/config/KafkaProducerConfig.java
+++ b/apps/backend/src/main/java/com/example/devboard/config/KafkaProducerConfig.java
@@ -1,0 +1,36 @@
+package com.example.devboard.config;
+
+import com.example.devboard.dto.TaskEvent;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, TaskEvent> taskEventProducerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, TaskEvent> taskEventKafkaTemplate() {
+        return new KafkaTemplate<>(taskEventProducerFactory());
+    }
+}

--- a/apps/backend/src/main/java/com/example/devboard/dto/TaskEvent.java
+++ b/apps/backend/src/main/java/com/example/devboard/dto/TaskEvent.java
@@ -1,0 +1,15 @@
+package com.example.devboard.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+public class TaskEvent {
+    private String eventType;
+    private Long taskId;
+    private Instant timestamp;
+    private Long userId;
+}

--- a/apps/backend/src/main/java/com/example/devboard/service/TaskEventProducer.java
+++ b/apps/backend/src/main/java/com/example/devboard/service/TaskEventProducer.java
@@ -1,0 +1,47 @@
+package com.example.devboard.service;
+
+import com.example.devboard.dto.TaskEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TaskEventProducer {
+
+    private final KafkaTemplate<String, TaskEvent> kafkaTemplate;
+
+    @Value("${devboard.kafka.topics.task-events}")
+    private String taskEventsTopic;
+
+    public void publishTaskCreatedEvent(Long taskId, Long userId) {
+        publishEvent("TASK_CREATED", taskId, userId);
+    }
+
+    public void publishTaskUpdatedEvent(Long taskId, Long userId) {
+        publishEvent("TASK_UPDATED", taskId, userId);
+    }
+
+    private void publishEvent(String eventType, Long taskId, Long userId) {
+        TaskEvent event = TaskEvent.builder()
+                .eventType(eventType)
+                .taskId(taskId)
+                .timestamp(Instant.now())
+                .userId(userId)
+                .build();
+
+        kafkaTemplate.send(taskEventsTopic, String.valueOf(taskId), event)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("Failed to publish {} event for task {}", eventType, taskId, ex);
+                    } else {
+                        log.info("Published {} event for task {} to topic {}", eventType, taskId, taskEventsTopic);
+                    }
+                });
+    }
+}

--- a/apps/backend/src/main/java/com/example/devboard/service/TaskService.java
+++ b/apps/backend/src/main/java/com/example/devboard/service/TaskService.java
@@ -29,6 +29,7 @@ public class TaskService {
     private final TaskRepository taskRepository;
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
+    private final TaskEventProducer taskEventProducer;
     
     public List<TaskResponse> getAllTasks() {
         return taskRepository.findAll().stream()
@@ -159,6 +160,7 @@ public class TaskService {
         }
         
         Task savedTask = taskRepository.save(task);
+        taskEventProducer.publishTaskCreatedEvent(savedTask.getId(), creatorId);
         return convertToResponse(savedTask);
     }
     
@@ -193,6 +195,7 @@ public class TaskService {
         }
         
         Task updatedTask = taskRepository.save(task);
+        taskEventProducer.publishTaskUpdatedEvent(updatedTask.getId(), userId);
         return convertToResponse(updatedTask);
     }
     

--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -26,8 +26,18 @@ spring:
       enabled: true
       path: /h2-console
 
+  # Kafka Producer Configuration
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
 # DevBoard Application Configuration
 devboard:
   app:
     jwtSecret: ${JWT_SECRET:defaultSecretKeyForDevelopmentOnly}
     jwtExpirationMs: ${JWT_EXPIRATION_MS:86400000} # 24 hours
+  kafka:
+    topics:
+      task-events: ${TASK_EVENTS_TOPIC:devboard.task.events}

--- a/apps/backend/src/test/java/com/example/devboard/service/TaskServiceTest.java
+++ b/apps/backend/src/test/java/com/example/devboard/service/TaskServiceTest.java
@@ -1,6 +1,8 @@
 package com.example.devboard.service;
 
 import com.example.devboard.dto.TaskResponse;
+import com.example.devboard.dto.TaskCreateRequest;
+import com.example.devboard.dto.TaskUpdateRequest;
 import com.example.devboard.entity.Task;
 import com.example.devboard.entity.User;
 import com.example.devboard.repository.CommentRepository;
@@ -16,8 +18,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,6 +35,9 @@ class TaskServiceTest {
 
     @Mock
     private CommentRepository commentRepository;
+
+    @Mock
+    private TaskEventProducer taskEventProducer;
 
     @InjectMocks
     private TaskService taskService;
@@ -353,5 +360,85 @@ class TaskServiceTest {
 
         // Assert - Should return all tasks as whitespace search is ignored
         assertThat(result).hasSize(2);
+    }
+
+    @Test
+    void createTask_PublishesTaskCreatedEvent() {
+        // Arrange
+        TaskCreateRequest request = TaskCreateRequest.builder()
+                .title("New Task")
+                .description("Task Description")
+                .status("TODO")
+                .priority("MEDIUM")
+                .assigneeId(2L)
+                .build();
+
+        Task savedTask = Task.builder()
+                .id(100L)
+                .title("New Task")
+                .description("Task Description")
+                .status(Task.TaskStatus.TODO)
+                .priority(Task.TaskPriority.MEDIUM)
+                .creator(user1)
+                .assignee(user2)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user1));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(user2));
+        when(taskRepository.save(org.mockito.ArgumentMatchers.any(Task.class))).thenReturn(savedTask);
+        when(commentRepository.countByTaskId(100L)).thenReturn(0L);
+
+        // Act
+        TaskResponse response = taskService.createTask(request, 1L);
+
+        // Assert
+        assertThat(response.getId()).isEqualTo(100L);
+        verify(taskEventProducer).publishTaskCreatedEvent(100L, 1L);
+    }
+
+    @Test
+    void updateTask_PublishesTaskUpdatedEvent() {
+        // Arrange
+        TaskUpdateRequest request = TaskUpdateRequest.builder()
+                .title("Updated Task")
+                .status("IN_PROGRESS")
+                .build();
+
+        Task existingTask = Task.builder()
+                .id(200L)
+                .title("Original Task")
+                .description("Original Description")
+                .status(Task.TaskStatus.TODO)
+                .priority(Task.TaskPriority.HIGH)
+                .creator(user1)
+                .assignee(user2)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        Task updatedTask = Task.builder()
+                .id(200L)
+                .title("Updated Task")
+                .description("Original Description")
+                .status(Task.TaskStatus.IN_PROGRESS)
+                .priority(Task.TaskPriority.HIGH)
+                .creator(user1)
+                .assignee(user2)
+                .createdAt(existingTask.getCreatedAt())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        when(taskRepository.findById(200L)).thenReturn(Optional.of(existingTask));
+        when(taskRepository.save(existingTask)).thenReturn(updatedTask);
+        when(commentRepository.countByTaskId(200L)).thenReturn(0L);
+
+        // Act
+        TaskResponse response = taskService.updateTask(200L, request, 99L);
+
+        // Assert
+        assertThat(response.getStatus()).isEqualTo("IN_PROGRESS");
+        verify(taskEventProducer).publishTaskUpdatedEvent(200L, 99L);
     }
 }


### PR DESCRIPTION
### Motivation
- Introduce asynchronous task lifecycle events so other services can react to task creation and updates via Kafka.

### Description
- Add `spring-kafka` dependency to `apps/backend/pom.xml` and configure producer properties in `application.yml` under `spring.kafka` and `devboard.kafka.topics.task-events`.
- Add `KafkaProducerConfig` to provide a `ProducerFactory<String, TaskEvent>` and a `KafkaTemplate<String, TaskEvent>` using JSON serialization.
- Add `TaskEvent` DTO and `TaskEventProducer` service that builds `TaskEvent` instances and publishes `TASK_CREATED` and `TASK_UPDATED` messages to the configured topic, logging success/failure.
- Wire `TaskEventProducer` into `TaskService` and call `publishTaskCreatedEvent` after `createTask` and `publishTaskUpdatedEvent` after `updateTask`; update unit tests to mock and verify event publishing.

### Testing
- Ran unit tests for the service layer, including `TaskServiceTest`, and verified the new tests `createTask_PublishesTaskCreatedEvent` and `updateTask_PublishesTaskUpdatedEvent` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eddf2159bc8331bfcb633538413b48)