### PR TITLE
Add devboard-event-service Kafka consumer and align topic name

### DIFF
--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -40,4 +40,4 @@ devboard:
     jwtExpirationMs: ${JWT_EXPIRATION_MS:86400000} # 24 hours
   kafka:
     topics:
-      task-events: ${TASK_EVENTS_TOPIC:devboard.task.events}
+      task-events: ${TASK_EVENTS_TOPIC:devboard.tasks}

--- a/apps/devboard-event-service/pom.xml
+++ b/apps/devboard-event-service/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.2</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>devboard-event-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>devboard-event-service</name>
+    <description>Kafka event consumer service for DevBoard</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/apps/devboard-event-service/src/main/java/com/example/devboard/eventservice/DevboardEventServiceApplication.java
+++ b/apps/devboard-event-service/src/main/java/com/example/devboard/eventservice/DevboardEventServiceApplication.java
@@ -1,0 +1,12 @@
+package com.example.devboard.eventservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DevboardEventServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DevboardEventServiceApplication.class, args);
+    }
+}

--- a/apps/devboard-event-service/src/main/java/com/example/devboard/eventservice/listener/TaskEventListener.java
+++ b/apps/devboard-event-service/src/main/java/com/example/devboard/eventservice/listener/TaskEventListener.java
@@ -1,0 +1,15 @@
+package com.example.devboard.eventservice.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class TaskEventListener {
+
+    @KafkaListener(topics = "${devboard.kafka.topics.task-events}", groupId = "${spring.kafka.consumer.group-id}")
+    public void consumeTaskEvents(String eventPayload) {
+        log.info("Consumed task event from topic devboard.tasks: {}", eventPayload);
+    }
+}

--- a/apps/devboard-event-service/src/main/resources/application.yml
+++ b/apps/devboard-event-service/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  application:
+    name: devboard-event-service
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: ${KAFKA_CONSUMER_GROUP:devboard-event-service}
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
+devboard:
+  kafka:
+    topics:
+      task-events: ${TASK_EVENTS_TOPIC:devboard.tasks}


### PR DESCRIPTION
### Motivation
- Provide a lightweight microservice to consume task events from Kafka so events produced by the backend can be processed or observed separately. 
- Align producer and consumer by standardizing the topic to `devboard.tasks`.

### Description
- Added a new Spring Boot service at `apps/devboard-event-service` with a Maven `pom.xml` including `spring-kafka` and Java 21 compatibility.
- Implemented application entrypoint `DevboardEventServiceApplication` to bootstrap the consumer service.
- Implemented `TaskEventListener` which uses `@KafkaListener` bound to the configured topic property and logs consumed message payloads.
- Added consumer configuration in `apps/devboard-event-service/src/main/resources/application.yml` and updated the backend default topic in `apps/backend/src/main/resources/application.yml` from `devboard.task.events` to `devboard.tasks`.

### Testing
- Attempted to run backend tests with `./mvnw test -q` but the run failed in this environment because the Maven wrapper could not download the Maven distribution (network/registry constraint).
- Attempted to run tests for the new service with `mvn -q test` but the run failed due to inability to resolve Spring Boot parent artifacts from Maven Central (403 Forbidden in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede25c0fb88331b4307a5b8773bf90)