### PR TITLE
fix(frontend): restore Vite dev proxy for /api requests

### DIFF
--- a/apps/frontend/vite.config.js
+++ b/apps/frontend/vite.config.js
@@ -8,6 +8,7 @@ export default defineConfig(({ command, mode }) => {
   
   // Determine if we're in production mode
   const isProduction = mode === 'production'
+  const apiTarget = env.VITE_API_URL || 'http://localhost:8080'
   
   return {
     plugins: [vue()],
@@ -39,6 +40,12 @@ export default defineConfig(({ command, mode }) => {
       port: parseInt(env.VITE_DEV_SERVER_PORT) || 5173,
       hmr: {
         port: parseInt(env.VITE_DEV_SERVER_PORT) || 5173
+      },
+      proxy: {
+        '/api': {
+          target: apiTarget,
+          changeOrigin: true
+        }
       }
     },
     


### PR DESCRIPTION
### Motivation
- Local frontend was making API calls to the Vite dev origin (`localhost:5173`) instead of the Spring Boot backend (`localhost:8080`), causing `/api/*` requests to hit Vite and return 404.
- Frontend service modules use relative API paths (e.g. `/api`, `/api/auth`), so a dev proxy is required to forward those requests to the backend during local development.

### Description
- Added `apiTarget` in `apps/frontend/vite.config.js` that reads from `VITE_API_URL` with a fallback to `http://localhost:8080`.
- Restored a Vite dev server `proxy` mapping so `'/api'` is forwarded to the backend (`target: apiTarget`) with `changeOrigin: true`.
- Change is limited to `apps/frontend/vite.config.js` and preserves existing dev server/HMR configuration.

### Testing
- Built the frontend with `cd apps/frontend && npm run build`, and the Vite build completed successfully (production bundle produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf559b37c8331b4ad2e75acaa21d4)