### PR TITLE
Add Lombok dependency and minor formatting fix in devboard-event-service

### DIFF
--- a/apps/devboard-event-service/pom.xml
+++ b/apps/devboard-event-service/pom.xml
@@ -29,6 +29,11 @@
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/apps/devboard-event-service/src/main/java/com/example/devboard/eventservice/listener/TaskEventListener.java
+++ b/apps/devboard-event-service/src/main/java/com/example/devboard/eventservice/listener/TaskEventListener.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class TaskEventListener {
-
     @KafkaListener(topics = "${devboard.kafka.topics.task-events}", groupId = "${spring.kafka.consumer.group-id}")
     public void consumeTaskEvents(String eventPayload) {
         log.info("Consumed task event from topic devboard.tasks: {}", eventPayload);


### PR DESCRIPTION
### Motivation
- Enable use of Lombok annotations (e.g. `@Slf4j`) in the `devboard-event-service` module by adding the Lombok dependency to the POM so generated code and logging annotations resolve at compile time.

### Description
- Add an optional `org.projectlombok:lombok` dependency to `apps/devboard-event-service/pom.xml` and remove an extraneous blank line in `TaskEventListener.java` for a minor formatting cleanup.

### Testing
- Ran `mvn -f apps/devboard-event-service/pom.xml test` and the module built and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edfcd8423c83319b95eb8fd73c3380)