### PR TITLE
Publish task events only after DB transaction commits

### DIFF
--- a/apps/backend/src/main/java/com/example/devboard/service/TaskService.java
+++ b/apps/backend/src/main/java/com/example/devboard/service/TaskService.java
@@ -16,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -160,7 +162,7 @@ public class TaskService {
         }
         
         Task savedTask = taskRepository.save(task);
-        taskEventProducer.publishTaskCreatedEvent(savedTask.getId(), creatorId);
+        publishEventAfterCommit(() -> taskEventProducer.publishTaskCreatedEvent(savedTask.getId(), creatorId));
         return convertToResponse(savedTask);
     }
     
@@ -195,7 +197,7 @@ public class TaskService {
         }
         
         Task updatedTask = taskRepository.save(task);
-        taskEventProducer.publishTaskUpdatedEvent(updatedTask.getId(), userId);
+        publishEventAfterCommit(() -> taskEventProducer.publishTaskUpdatedEvent(updatedTask.getId(), userId));
         return convertToResponse(updatedTask);
     }
     
@@ -296,5 +298,19 @@ public class TaskService {
         
         log.info("Admin deleting task: {} ({})", task.getId(), task.getTitle());
         taskRepository.delete(task);
+    }
+
+    private void publishEventAfterCommit(Runnable eventPublisher) {
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    eventPublisher.run();
+                }
+            });
+            return;
+        }
+
+        eventPublisher.run();
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure Kafka task events are emitted only when the surrounding database transaction actually commits to avoid downstream inconsistency when a transaction is rolled back.

### Description
- Add `publishEventAfterCommit` helper to `TaskService` that uses `TransactionSynchronizationManager.registerSynchronization(...).afterCommit(...)` to defer event publication.
- Replace direct calls to `taskEventProducer.publishTaskCreatedEvent(...)` and `taskEventProducer.publishTaskUpdatedEvent(...)` with deferred calls via `publishEventAfterCommit` in `createTask` and `updateTask` respectively.
- Add imports for `TransactionSynchronization` and `TransactionSynchronizationManager` in `TaskService`.
- Changes are confined to `apps/backend/src/main/java/com/example/devboard/service/TaskService.java`.

### Testing
- Attempted to compile the backend with `./mvnw -q -DskipTests compile`, but the Maven wrapper download failed due to network access to Maven Central, so compilation could not be verified in this environment (failed).
- No further automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee01956668833184795cea908cee9d)