### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/apps/backend/src/main/java/com/example/devboard/config/SecurityConfig.java
+++ b/apps/backend/src/main/java/com/example/devboard/config/SecurityConfig.java
@@ -48,7 +48,9 @@ public class SecurityConfig {
     
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.cors().and().csrf().disable()
+        http.cors().and().csrf(csrf -> csrf
+                        .ignoringRequestMatchers("/h2-console/**")
+                )
                 .exceptionHandling().authenticationEntryPoint(unauthorizedHandler).and()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
                 .authorizeHttpRequests(authz -> authz


### PR DESCRIPTION
Potential fix for [https://github.com/sunmingtao/devBoard/security/code-scanning/1](https://github.com/sunmingtao/devBoard/security/code-scanning/1)

Use Spring Security’s CSRF support instead of disabling it globally.

Best fix here (without changing the app’s intended JWT/stateless behavior) is to replace:
- `http.cors().and().csrf().disable()`
with
- `http.cors().and().csrf(csrf -> csrf.ignoringRequestMatchers("/h2-console/**"))`

This keeps CSRF enabled by default for the application while allowing H2 console paths to continue working. No new methods or classes are needed; only update the security chain configuration in `apps/backend/src/main/java/com/example/devboard/config/SecurityConfig.java` at the `filterChain` method around line 51.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
